### PR TITLE
allow minor version for python 3.12.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["FCN",  "physical design"]
 license = { file = "LICENSE" }
-requires-python = "<=3.12"
+requires-python = "~=3.12"
 dynamic = ["version"]
 
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["FCN",  "physical design"]
 license = { file = "LICENSE" }
-requires-python =  "~=3.11.0,~=3.12"
+requires-python =  "<3.13"
 dynamic = ["version"]
 
 dependencies = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,7 @@ authors = [
 ]
 keywords = ["FCN",  "physical design"]
 license = { file = "LICENSE" }
-requires-python = "~=3.12"
+requires-python =  "~=3.11.0,~=3.12"
 dynamic = ["version"]
 
 dependencies = [


### PR DESCRIPTION
Title: Allow higher minor version for Python 3.12.x

Description:
This pull request updates the `requires-python` field in the `pyproject.toml` file to allow a higher minor version of Python 3.12.x.

Changes:

1. Updated `requires-python` field to `"<=3.13"`, which allows any Python version that is compatible with 3.12.3, including higher minor versions.

This change will provide more flexibility for users who may be using a higher minor version of Python 3.12.x in their projects.

Please review and merge this pull request.

Thank you for your presentation today!

Regrads Liam
