### PR TITLE
Modernize runtime support and harden placement

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,44 +2,45 @@ name-template: "NanoPlaceR $RESOLVED_VERSION Release"
 tag-template: "v$RESOLVED_VERSION"
 categories:
   - title: "🚀 Features and Enhancements"
-    labels:
-      - "feature"
-      - "usability"
+    when:
+      labels:
+        - "feature"
+        - "usability"
   - title: "🐛 Bug Fixes"
-    labels:
-      - "bug"
+    when:
+      labels:
+        - "bug"
   - title: "📄 Documentation"
-    labels:
-      - "documentation"
+    when:
+      labels:
+        - "documentation"
   - title: "🤖 CI"
-    labels:
-      - "continuous integration"
+    when:
+      labels:
+        - "continuous integration"
   - title: "📦 Packaging"
-    labels:
-      - "packaging"
+    when:
+      labels:
+        - "packaging"
   - title: "⬆️ Dependencies"
     collapse-after: 5
-    labels:
-      - "dependencies"
-      - "submodules"
-      - "github_actions"
+    when:
+      labels:
+        - "dependencies"
+        - "submodules"
+        - "github_actions"
+  - type: version-resolver
+    semver-increment: major
+    when:
+      label: "major"
+  - type: version-resolver
+    semver-increment: minor
+    when:
+      label: "minor"
+  - type: version-resolver
+    semver-increment: patch
 change-template: "- $TITLE @$AUTHOR (#$NUMBER)"
 change-title-escapes: '\<*_&'
-version-resolver:
-  major:
-    labels:
-      - "major"
-  minor:
-    labels:
-      - "minor"
-  patch:
-    labels:
-      - "patch"
-  default: patch
-autolabeler:
-  - label: "dependencies"
-    title:
-      - "/update pre-commit hooks/i"
 
 template: |
   ## What Changed 👀

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -22,16 +22,16 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           languages: python
           build-mode: none
           queries: +security-and-quality
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,19 +15,31 @@ concurrency:
 permissions: {}
 
 jobs:
+  quality:
+    name: Quality checks
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - name: Run pre-commit
+        run: pipx run pre-commit run --all-files --show-diff-on-failure
+
   build_wheel:
     name: Build wheel
     runs-on: ubuntu-latest
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.13"
+          python-version: "3.14"
         name: Install Python
       - name: Build wheel
         run: pipx run build --wheel
@@ -39,7 +51,8 @@ jobs:
           python -m pytest
           python -m pip check
           mnt.nanoplacer --help
-      - uses: actions/upload-artifact@v7
+      - if: github.event_name == 'release'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact-wheel
           path: dist/*.whl
@@ -51,13 +64,13 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false
-      - uses: actions/setup-python@v7
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
-          python-version: "3.10"
+          python-version: "3.11"
         name: Install Python
       - name: Build sdist
         run: pipx run build --sdist
@@ -69,7 +82,8 @@ jobs:
           python -m pytest
           python -m pip check
           mnt.nanoplacer --help
-      - uses: actions/upload-artifact@v7
+      - if: github.event_name == 'release'
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: artifact-sdist
           path: dist/*.tar.gz
@@ -84,11 +98,11 @@ jobs:
       url: https://pypi.org/p/mnt.nanoplacer
     permissions:
       id-token: write
-    needs: [build_wheel, build_sdist]
+    needs: [quality, build_wheel, build_sdist]
     steps:
-      - uses: actions/download-artifact@v8
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           pattern: artifact-*
           path: dist
           merge-multiple: true
-      - uses: pypa/gh-action-pypi-publish@release/v1
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -12,9 +12,9 @@ jobs:
   update_release_draft:
     permissions:
       contents: write
-      pull-requests: write
+      pull-requests: read
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@34d80673e067bdc0c24568d3af899c216adcfaa9 # v7.7.0
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ NanoPlaceR is an open-source physical-design tool for field-coupled nanocomputin
 
 ## Installation
 
-NanoPlaceR requires Python 3.10 or newer and `mnt.pyfiction` 0.8 or newer. The CI suite covers Python 3.10 and 3.13.
+NanoPlaceR supports Python 3.11 through 3.14 and requires `mnt.pyfiction` 0.8 or newer. The CI suite covers both ends of that range.
 
 ```console
 python -m venv .venv

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,15 +15,15 @@ authors = [
 keywords = ["FCN", "physical design"]
 license = "MIT"
 license-files = ["LICENSE"]
-requires-python = ">=3.10"
+requires-python = ">=3.11"
 dynamic = ["version"]
 
 dependencies = [
-    "gymnasium>=0.28.1",
+    "gymnasium>=0.29.1",
     "mnt.pyfiction>=0.8.0",
     "networkx>=3.2.1",
     "numpy>=1.26.3",
-    "sb3-contrib>=2.2.1",
+    "sb3-contrib>=2.8.0",
     "tensorboard>=2.15.1",
 ]
 
@@ -34,10 +34,10 @@ classifiers = [
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3 :: Only",
-    "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
     "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Intended Audience :: Science/Research",
     "Natural Language :: English",
     "Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)",
@@ -66,7 +66,7 @@ Research = "https://www.cda.cit.tum.de/research/fcn/"
 line-length = 120
 namespace-packages = ["src/mnt"]
 src = ["src"]
-target-version = "py310"
+target-version = "py311"
 
 [tool.ruff.lint]
 select = [

--- a/src/mnt/nanoplacer/main.py
+++ b/src/mnt/nanoplacer/main.py
@@ -2,7 +2,6 @@ import argparse
 from pathlib import Path
 
 from sb3_contrib import MaskablePPO
-from sb3_contrib.common.maskable.policies import MaskableActorCriticPolicy
 
 from mnt.nanoplacer.placement_envs.nano_placement_env import NanoPlacementEnv
 from mnt.nanoplacer.placement_envs.utils import layout_dimensions
@@ -21,20 +20,23 @@ def create_layout(
     verbose: int = 1,
     optimize: bool = True,
 ) -> None:
+    effective_clocking_scheme = "2DDWave" if technology.lower() == "sidb" else clocking_scheme
+
     for folder in (Path("layouts"), Path("models"), Path("tensorboard")):
         folder.mkdir(parents=True, exist_ok=True)
 
     if minimal_layout_dimension:
-        dimensions = layout_dimensions.get(clocking_scheme, {}).get(benchmark, {}).get(function)
+        dimensions = layout_dimensions.get(effective_clocking_scheme, {}).get(benchmark, {}).get(function)
         if dimensions is None:
             msg = (
-                f"No predefined layout dimensions for {benchmark}/{function} with the {clocking_scheme} clocking scheme"
+                f"No predefined layout dimensions for {benchmark}/{function} with the "
+                f"{effective_clocking_scheme} clocking scheme"
             )
             raise ValueError(msg)
         layout_width, layout_height = dimensions
 
     env = NanoPlacementEnv(
-        clocking_scheme=clocking_scheme,
+        clocking_scheme=effective_clocking_scheme,
         technology=technology,
         layout_width=layout_width,
         layout_height=layout_height,
@@ -46,17 +48,20 @@ def create_layout(
 
     model_path = Path("models") / (
         f"ppo_{technology}_{benchmark}_{function}_"
-        f"{'ROW' if technology == 'SiDB' else clocking_scheme}_{layout_width}x{layout_height}.zip"
+        f"{'ROW' if technology.lower() == 'sidb' else effective_clocking_scheme}_{layout_width}x{layout_height}.zip"
     )
     if reset_model or not model_path.exists():
         model = MaskablePPO(
-            MaskableActorCriticPolicy,
+            "MlpPolicy",
             env,
             batch_size=512,
             verbose=1 if verbose in (2, 3) else 0,
             gamma=0.995,
             learning_rate=0.001,
-            tensorboard_log=str(Path("tensorboard") / function),
+            tensorboard_log=str(
+                Path("tensorboard")
+                / f"{technology}_{benchmark}_{function}_{effective_clocking_scheme}_{layout_width}x{layout_height}"
+            ),
         )
         reset_num_timesteps = True
     else:

--- a/src/mnt/nanoplacer/placement_envs/nano_placement_env.py
+++ b/src/mnt/nanoplacer/placement_envs/nano_placement_env.py
@@ -1,4 +1,3 @@
-from collections import defaultdict
 from pathlib import Path
 from time import time
 
@@ -27,11 +26,18 @@ class NanoPlacementEnv(gym.Env):
         """Constructor."""
         super().__init__()
 
+        if technology.lower() not in {"qca", "sidb", "gate-level"}:
+            msg = f"Not a supported technology: {technology}"
+            raise ValueError(msg)
+        if layout_width <= 0 or layout_height <= 0:
+            msg = "Layout dimensions must be positive"
+            raise ValueError(msg)
+
         self.last_pos = None
         self.technology = technology
         self.clocking_scheme = (
             "2DDWave"
-            if (self.technology == "SiDB" or clocking_scheme.upper() == "2DDWAVE")
+            if (self.technology.lower() == "sidb" or clocking_scheme.upper() == "2DDWAVE")
             else clocking_scheme.upper()
         )
 
@@ -55,7 +61,7 @@ class NanoPlacementEnv(gym.Env):
             self.pi_names,
             self.po_names,
         ) = create_action_list(self.benchmark, self.function)
-        self.observation_space = gym.spaces.Discrete(max(self.actions))
+        self.observation_space = gym.spaces.Discrete(len(self.actions) + 1)
 
         self.action_space = gym.spaces.Discrete(self.layout_width * self.layout_height)
 
@@ -64,14 +70,14 @@ class NanoPlacementEnv(gym.Env):
         self.current_po = 0
 
         self.placement_possible = True
-        self.node_dict = defaultdict(int)
+        self.node_dict: dict[int, int] = {}
         self.max_placed_nodes = 0
         self.current_tries = 0
         self.max_tries = 0
+        self.tried_positions: set[tuple[int, int]] = set()
         self.start = time()
         self.placement_times = []
         self.occupied_tiles = np.zeros([self.layout_width, self.layout_height], dtype=int)
-        self.gates = np.zeros([self.layout_width, self.layout_height], dtype=int)
         self.verbose = verbose
         self.layout_mask_width = 4
         self.layout_mask_height = 4
@@ -97,14 +103,14 @@ class NanoPlacementEnv(gym.Env):
         self.current_po = 0
         self.current_tries = 0
         self.placement_possible = True
-        self.node_dict = defaultdict(int)
+        self.node_dict = {}
         self.occupied_tiles = np.zeros([self.layout_width, self.layout_height], dtype=int)
 
         observation = self.current_node
 
         self.last_pos = None
         self.max_tries = 0
-        self.gates = np.zeros([self.layout_width, self.layout_height], dtype=int)
+        self.tried_positions.clear()
         self.layout_mask_width = 4
         self.layout_mask_height = 4
 
@@ -121,6 +127,10 @@ class NanoPlacementEnv(gym.Env):
 
         :return:          Observation, reward, termination, truncation, and info
         """
+        if not self.action_space.contains(action):
+            msg = f"Action {action} is outside the action space"
+            raise ValueError(msg)
+
         x, y = map_to_multidiscrete(action, self.layout_width)
 
         preceding_nodes = list(self.DG.predecessors(self.actions[self.current_node]))
@@ -141,6 +151,7 @@ class NanoPlacementEnv(gym.Env):
             ]:
                 if self.current_tries == 0:
                     self.max_tries = sum(self.action_masks())
+                self.tried_positions.add((x, y))
 
                 layout_node_1 = self.node_dict[preceding_nodes[0]]
                 layout_tile_1 = self.layout.get_tile(layout_node_1)
@@ -195,6 +206,7 @@ class NanoPlacementEnv(gym.Env):
             ]:
                 if self.current_tries == 0:
                     self.max_tries = sum(self.action_masks())
+                self.tried_positions.add((x, y))
 
                 layout_node = self.node_dict[preceding_nodes[0]]
                 layout_tile = self.layout.get_tile(layout_node)
@@ -237,8 +249,8 @@ class NanoPlacementEnv(gym.Env):
 
             if placed_node:
                 self.current_node += 1
+                self.tried_positions.clear()
                 self.occupied_tiles[x][y] = 1
-                self.gates[x][y] = 1
                 self.layout.obstruct_coordinate((x, y, 0))
                 self.layout.obstruct_coordinate((x, y, 1))
 
@@ -272,7 +284,7 @@ class NanoPlacementEnv(gym.Env):
         elif self.technology.lower() == "gate-level":
             path = output_dir / (
                 f"{self.function}_ONE_{self.clocking_scheme}_NanoPlaceR_"
-                f"{'Un' if not self.optimize else ''}Opt_UnOrd.fgl"
+                f"{'Un' if not self.optimize else ''}Opt_UnOrd_area.fgl"
             )
             pyfiction.write_fgl_layout(
                 self.layout,
@@ -328,6 +340,9 @@ class NanoPlacementEnv(gym.Env):
         Additionally, checks termination criteria to stop current placement.
 
         :return:    Action masks"""
+        if self.current_node >= len(self.actions):
+            return [True] * self.action_space.n
+
         preceding_nodes = list(self.DG.predecessors(self.actions[self.current_node]))
         possible_positions_nodes = np.ones([self.layout_width, self.layout_height], dtype=int)
 
@@ -363,7 +378,7 @@ class NanoPlacementEnv(gym.Env):
                 possible_positions_nodes[loc.x - 1 : self.layout_mask_width, self.layout_height - 1] = 0
             elif self.clocking_scheme.upper() in ("USE", "RES", "ESR"):
                 possible_positions_nodes[0, :] = 0
-                possible_positions_nodes[self.layout_width - 1, 0] = 0
+                possible_positions_nodes[self.layout_width - 1, :] = 0
                 possible_positions_nodes[:, 0] = 0
                 possible_positions_nodes[:, self.layout_height - 1] = 0
             else:
@@ -448,7 +463,7 @@ class NanoPlacementEnv(gym.Env):
                 if self.clocking_scheme.upper() in ("USE", "RES", "ESR"):
                     goals = []
                     if (width % 2 == 0) and (height % 2 == 0):
-                        goals.append((0, width - 1))
+                        goals.append((0, height - 1))
                     elif (width % 2 == 1) and (height % 2 == 1):
                         goals.append((width - 1, 0))
                     elif (width % 2 == 0) and (height % 2 == 1):
@@ -459,14 +474,7 @@ class NanoPlacementEnv(gym.Env):
                     else:
                         msg = "Unable to determine a routing goal"
                         raise ValueError(msg)
-                    for goal in goals:
-                        overall = False
-                        if len(pyfiction.a_star(self.layout, tile, goal, params)) == 0:
-                            possible = False
-                        else:
-                            overall = True
-                        if overall:
-                            possible = True
+                    possible = any(pyfiction.a_star(self.layout, tile, goal, params) for goal in goals)
                 elif (
                     self.clocking_scheme.upper() == "2DDWAVE"
                     and possible
@@ -496,12 +504,14 @@ class NanoPlacementEnv(gym.Env):
 
                 if not possible:
                     self.placement_possible = False
-        mask_occupied = self.occupied_tiles.flatten(order="F") == 0
-        mask = possible_positions_nodes.flatten(order="F") == 0
+        mask = (possible_positions_nodes == 0) & (self.occupied_tiles == 0)
+        for tried_position in self.tried_positions:
+            mask[tried_position] = False
+        mask = mask.flatten(order="F")
         if not mask.any():
             self.placement_possible = False
             return [True] * len(mask)
-        return (mask & mask_occupied).tolist()
+        return mask.tolist()
 
     def calculate_reward(self, x: int, y: int, placed_node: bool) -> tuple[float, bool]:
         """Calculate reward based on whether a node was placed or not.
@@ -543,8 +553,5 @@ class NanoPlacementEnv(gym.Env):
 
         return float(reward), done
 
-    def render(self, mode: str = "human") -> None:
-        """Render current placement (not implemented).
-
-        :param mode:    Render mode
-        """
+    def render(self) -> None:
+        """Render current placement (not implemented)."""

--- a/src/mnt/nanoplacer/placement_envs/utils/placement_utils.py
+++ b/src/mnt/nanoplacer/placement_envs/utils/placement_utils.py
@@ -1,3 +1,4 @@
+from collections import deque
 from collections.abc import Iterator
 from pathlib import Path
 
@@ -39,15 +40,15 @@ def topological_generations(dg: nx.DiGraph) -> Iterator[int]:
     :return:           Current node from the network
     """
     indegree_map = {v: d for v, d in dg.in_degree() if d > 0}
-    zero_indegree = [v for v, d in dg.in_degree() if d == 0]
+    zero_indegree = deque(v for v, d in dg.in_degree() if d == 0)
 
     while zero_indegree:
-        node = zero_indegree.pop(0)
+        node = zero_indegree.popleft()
 
         for child in dg.neighbors(node):
             indegree_map[child] -= 1
             if indegree_map[child] == 0:
-                zero_indegree.insert(0, child)
+                zero_indegree.appendleft(child)
                 del indegree_map[child]
         yield node
 
@@ -78,6 +79,9 @@ def create_action_list(
     """
     dir_path = Path(__file__).parents[2].resolve()
     path = dir_path / "benchmarks" / benchmark / f"{function}.v"
+    if not path.is_file():
+        msg = f"Benchmark function {benchmark}/{function} does not exist"
+        raise ValueError(msg)
     network = pyfiction.read_technology_network(str(path))
 
     pi_names = [network.get_name(pi) for pi in network.pis()]
@@ -86,18 +90,19 @@ def create_action_list(
     params = pyfiction.fanout_substitution_params()
     params.strategy = pyfiction.substitution_strategy.DEPTH
     network = pyfiction.fanout_substitution(network, params)
+    po_nodes = set(network.pos())
 
     dg = nx.DiGraph()
 
     # add nodes
     dg.add_nodes_from(network.pis())
     for gate in network.gates():
-        if gate not in network.pos():
+        if gate not in po_nodes:
             dg.add_node(gate)
 
     # add edges
     for x in network.gates():
-        if x not in network.pos():
+        if x not in po_nodes:
             for pre in network.fanins(x):
                 dg.add_edge(pre, x)
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -6,6 +6,7 @@ from gymnasium.utils.env_checker import check_env
 from sb3_contrib import MaskablePPO
 
 from mnt.nanoplacer.placement_envs.nano_placement_env import NanoPlacementEnv
+from mnt.nanoplacer.placement_envs.utils import map_to_discrete
 
 
 @pytest.fixture
@@ -48,6 +49,25 @@ def test_step_returns_gymnasium_values(env: NanoPlacementEnv) -> None:
     assert info == {}
 
 
+@pytest.mark.parametrize("action", [-1, 12])
+def test_step_rejects_actions_outside_action_space(env: NanoPlacementEnv, action: int) -> None:
+    with pytest.raises(ValueError, match="outside the action space"):
+        env.step(action)
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "message"),
+    [
+        ({"technology": "InvalidTech"}, "Not a supported technology"),
+        ({"layout_width": 0}, "Layout dimensions must be positive"),
+        ({"layout_height": -1}, "Layout dimensions must be positive"),
+    ],
+)
+def test_environment_rejects_invalid_configuration(kwargs: dict[str, object], message: str) -> None:
+    with pytest.raises(ValueError, match=message):
+        NanoPlacementEnv(**kwargs)
+
+
 def test_save_layout_dispatches_by_technology(
     env: NanoPlacementEnv, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
@@ -74,7 +94,7 @@ def test_save_layout_dispatches_by_technology(
     env.technology = "Gate-level"
     with patch("mnt.pyfiction.write_fgl_layout") as write_fgl:
         env.save_layout()
-    assert write_fgl.call_args.args[1] == str(Path("layouts/mux21_ONE_2DDWave_NanoPlaceR_Opt_UnOrd.fgl"))
+    assert write_fgl.call_args.args[1] == str(Path("layouts/mux21_ONE_2DDWave_NanoPlaceR_Opt_UnOrd_area.fgl"))
 
     env.technology = "InvalidTech"
     with pytest.raises(ValueError, match="Not a supported technology"):
@@ -90,7 +110,7 @@ def test_place_and_serialize_mux(env: NanoPlacementEnv, tmp_path: Path, monkeypa
 
     assert reward > 1000
     assert terminated is True
-    assert (tmp_path / "layouts/mux21_ONE_2DDWave_NanoPlaceR_Opt_UnOrd.fgl").is_file()
+    assert (tmp_path / "layouts/mux21_ONE_2DDWave_NanoPlaceR_Opt_UnOrd_area.fgl").is_file()
 
     env.technology = "QCA"
     env.save_layout()
@@ -107,6 +127,106 @@ def test_action_masks_are_plain_booleans(env: NanoPlacementEnv) -> None:
     assert len(masks) == env.action_space.n
     assert all(isinstance(mask, bool) for mask in masks)
     assert any(masks)
+
+
+def test_action_masks_return_safe_fallback_when_no_unoccupied_positions_remain(env: NanoPlacementEnv) -> None:
+    env.occupied_tiles.fill(1)
+
+    masks = env.action_masks()
+
+    assert masks == [True] * env.action_space.n
+    assert env.placement_possible is False
+
+
+def test_action_masks_accept_all_four_edges_for_use_outputs() -> None:
+    use_env = NanoPlacementEnv(
+        clocking_scheme="USE",
+        technology="Gate-level",
+        layout_width=5,
+        layout_height=5,
+        benchmark="trindade16",
+        function="mux21",
+        verbose=0,
+    )
+    use_env.current_node = len(use_env.actions) - 1
+    predecessor = next(iter(use_env.DG.predecessors(use_env.actions[use_env.current_node])))
+    use_env.layout.create_pi("source", (2, 2))
+    use_env.node_dict[predecessor] = use_env.layout.get_node((2, 2))
+    use_env.occupied_tiles[2, 2] = 1
+
+    with patch("mnt.pyfiction.a_star", return_value=[object()]):
+        masks = use_env.action_masks()
+
+    assert sum(masks) == 16
+    assert all(masks[map_to_discrete(4, y, 5)] for y in range(5))
+
+
+def test_action_masks_use_height_for_rectangular_routing_goal() -> None:
+    use_env = NanoPlacementEnv(
+        clocking_scheme="USE",
+        technology="Gate-level",
+        layout_width=5,
+        layout_height=3,
+        benchmark="trindade16",
+        function="mux21",
+        verbose=0,
+    )
+    use_env.current_node = len(use_env.actions) - 1
+    predecessor = next(iter(use_env.DG.predecessors(use_env.actions[use_env.current_node])))
+    use_env.layout.create_pi("source", (2, 1))
+    use_env.node_dict[predecessor] = use_env.layout.get_node((2, 1))
+
+    with patch("mnt.pyfiction.a_star", return_value=[object()]) as a_star:
+        use_env.action_masks()
+
+    assert a_star.call_args.args[2] == (0, 3)
+
+
+def test_action_masks_accept_any_reachable_routing_goal() -> None:
+    use_env = NanoPlacementEnv(
+        clocking_scheme="USE",
+        technology="Gate-level",
+        layout_width=4,
+        layout_height=3,
+        benchmark="trindade16",
+        function="mux21",
+        verbose=0,
+    )
+    use_env.current_node = len(use_env.actions) - 1
+    predecessor = next(iter(use_env.DG.predecessors(use_env.actions[use_env.current_node])))
+    use_env.layout.create_pi("source", (2, 1))
+    use_env.node_dict[predecessor] = use_env.layout.get_node((2, 1))
+
+    with patch("mnt.pyfiction.a_star", side_effect=([object()], [])):
+        use_env.action_masks()
+
+    assert use_env.placement_possible is True
+
+
+def test_action_masks_exclude_failed_route_position() -> None:
+    retry_env = NanoPlacementEnv(
+        clocking_scheme="2DDWave",
+        technology="Gate-level",
+        layout_width=5,
+        layout_height=6,
+        benchmark="trindade16",
+        function="mux21",
+        verbose=0,
+    )
+    for action in (3, 20, 10, 11, 28, 27):
+        retry_env.step(action)
+
+    assert retry_env.current_tries == 2
+    masks = retry_env.action_masks()
+    assert masks[28] is False
+    assert masks[27] is False
+
+
+def test_action_masks_allow_terminal_observation(env: NanoPlacementEnv) -> None:
+    env.current_node = len(env.actions)
+
+    assert env.observation_space.contains(env.current_node)
+    assert env.action_masks() == [True] * env.action_space.n
 
 
 def test_maskable_ppo_can_learn(env: NanoPlacementEnv, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,6 +1,6 @@
 import sys
 from pathlib import Path
-from unittest.mock import ANY, Mock, patch
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -19,13 +19,13 @@ def test_create_layout_starts_and_saves_a_new_model(tmp_path: Path, monkeypatch:
         create_layout(minimal_layout_dimension=False, time_steps=42, reset_model=True)
 
     ppo.assert_called_once_with(
-        ANY,
+        "MlpPolicy",
         env,
         batch_size=512,
         verbose=0,
         gamma=0.995,
         learning_rate=0.001,
-        tensorboard_log=str(Path("tensorboard") / "mux21"),
+        tensorboard_log=str(Path("tensorboard") / "Gate-level_trindade16_mux21_2DDWave_3x4"),
     )
     model.learn.assert_called_once_with(total_timesteps=42, log_interval=1, reset_num_timesteps=True)
     model.save.assert_called_once_with(Path("models/ppo_Gate-level_trindade16_mux21_2DDWave_3x4.zip"))
@@ -64,6 +64,20 @@ def test_create_layout_uses_iscas85_dimensions(tmp_path: Path, monkeypatch: pyte
 
     assert env.call_args.kwargs["layout_width"] == 7
     assert env.call_args.kwargs["layout_height"] == 7
+
+
+def test_create_layout_uses_2ddwave_dimensions_for_sidb(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.chdir(tmp_path)
+
+    with (
+        patch("mnt.nanoplacer.main.NanoPlacementEnv") as env,
+        patch("mnt.nanoplacer.main.MaskablePPO"),
+    ):
+        create_layout(technology="SiDB", clocking_scheme="USE", time_steps=0)
+
+    assert env.call_args.kwargs["clocking_scheme"] == "2DDWave"
+    assert env.call_args.kwargs["layout_width"] == 4
+    assert env.call_args.kwargs["layout_height"] == 3
 
 
 def test_create_layout_rejects_unknown_minimal_dimensions(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,5 @@
 import networkx as nx
+import pytest
 
 from mnt.nanoplacer.placement_envs.utils.placement_utils import (
     create_action_list,
@@ -47,3 +48,8 @@ def test_create_action_list() -> None:
     assert list(graph.edges()) == [(2, 7), (3, 8), (4, 5), (5, 6), (5, 8), (6, 7), (7, 9), (8, 9), (9, 10)]
     assert pi_names == ["in0", "in1", "in2"]
     assert po_names == ["out"]
+
+
+def test_create_action_list_rejects_unknown_function() -> None:
+    with pytest.raises(ValueError, match="EPFL/mux21 does not exist"):
+        create_action_list("EPFL", "mux21")


### PR DESCRIPTION
## Summary

- support Python 3.11 through 3.14 and raise the Gymnasium/SB3 floors to maintained versions
- fix occupied, exhausted, terminal, repeated-route, boundary, and rectangular action masks
- normalize SiDB clocking before dimension lookup and validate unsafe inputs before entering pyfiction
- emit MNTBench-compatible `_area.fgl` filenames and isolate TensorBoard runs by configuration
- enforce pre-commit in CI, pin action SHAs, migrate Release Drafter v7 config, and avoid unused artifact uploads

## Python 3.15

CPython 3.15.0rc2 passes the full runtime suite when PyTorch is installed from its separate wheel index, and `mnt.pyfiction` 0.8.0 works through its abi3 wheel. Normal PyPI resolution still fails because PyTorch has no cp315 wheel on PyPI, while grpcio falls back to a long source build. This PR therefore does not advertise 3.15 support yet.

## Validation

- 30 tests pass from the sdist on Python 3.11
- 30 tests pass from the wheel on Python 3.14
- exact declared lower bounds pass on Python 3.11
- full pre-commit suite passes
- wheel and sdist pass Twine checks
- Release Drafter config validates against the official v7.7 schema
- generated FGL basename parses correctly in mnt-bench